### PR TITLE
Fix #11

### DIFF
--- a/src/main/java/xyz/tcreopargh/ctintegration/CTIntegrationMod.java
+++ b/src/main/java/xyz/tcreopargh/ctintegration/CTIntegrationMod.java
@@ -9,6 +9,7 @@ import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import xyz.tcreopargh.ctintegration.cot.BaubleEventHandler;
 import xyz.tcreopargh.ctintegration.cot.BaubleItemRepresentation;
+import xyz.tcreopargh.ctintegration.cot.BaubleVanillaFactoryExpansion;
 import xyz.tcreopargh.ctintegration.gamestages.events.EventsExpansion;
 
 @Mod(
@@ -50,6 +51,7 @@ public class CTIntegrationMod {
             CraftTweakerAPI.registerClass(BaubleEventHandler.OnEquipped.class);
             CraftTweakerAPI.registerClass(BaubleEventHandler.OnUnequipped.class);
             CraftTweakerAPI.registerClass(BaubleEventHandler.WillAutoSync.class);
+            CraftTweakerAPI.registerClass(BaubleVanillaFactoryExpansion.class);
         }
     }
 

--- a/src/main/java/xyz/tcreopargh/ctintegration/cot/BaubleVanillaFactoryExpansion.java
+++ b/src/main/java/xyz/tcreopargh/ctintegration/cot/BaubleVanillaFactoryExpansion.java
@@ -7,9 +7,7 @@ import net.minecraftforge.fml.common.Loader;
 import stanhebben.zenscript.annotations.ZenExpansion;
 import stanhebben.zenscript.annotations.ZenMethodStatic;
 
-@ModOnly("contenttweaker")
 @ZenExpansion("mods.contenttweaker.VanillaFactory")
-@ZenRegister
 public class BaubleVanillaFactoryExpansion {
     @ZenMethodStatic
     public static BaubleItemRepresentation createBaubleItem(String unlocalizedName) {


### PR DESCRIPTION
Registers BaubleVanillaFactoryExpansion in first initialization event with the other Baubles expansion instead of with @ZenRegister and @ModOnly, which only supports one mod